### PR TITLE
Add Hermes Tweet plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,7 +44,7 @@
       "description": "Guide Hermes Agent X/Twitter workflows with Hermes Tweet, the native Xquik plugin for social listening, research, audits, and controlled publishing.",
       "author": {
         "name": "Xquik",
-        "url": "https://github.com/Xquik-dev"
+        "email": "support@xquik.com"
       },
       "keywords": ["hermes-agent", "xquik", "twitter", "x", "social-media", "automation"]
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,6 +37,16 @@
         "email": "flopspm@gmail.com"
       },
       "keywords": ["review", "coderabbit", "github", "pr", "pull-request", "bot-comments"]
+    },
+    {
+      "name": "hermes-tweet",
+      "source": "./plugins/hermes-tweet",
+      "description": "Guide Hermes Agent X/Twitter workflows with Hermes Tweet, the native Xquik plugin for social listening, research, audits, and controlled publishing.",
+      "author": {
+        "name": "Xquik",
+        "url": "https://github.com/Xquik-dev"
+      },
+      "keywords": ["hermes-agent", "xquik", "twitter", "x", "social-media", "automation"]
     }
   ]
 }

--- a/docs/plugin-catalog/hermes-tweet-plugin.md
+++ b/docs/plugin-catalog/hermes-tweet-plugin.md
@@ -1,0 +1,51 @@
+# Hermes Tweet Plugin
+
+**Name:** `hermes-tweet`
+
+**Description:** Guide Hermes Agent X/Twitter workflows with Hermes Tweet, the native Xquik plugin for social listening, research, audits, and controlled publishing.
+
+**Author:** Xquik
+
+**Version:** 0.1.6
+
+**Keywords:** hermes-agent, xquik, twitter, x, social-media, automation
+
+The Hermes Tweet plugin helps Claude Code users install and operate Hermes Tweet,
+the native Hermes Agent X/Twitter plugin for Xquik workflows.
+
+Use it for social listening, launch monitoring, support triage, creator
+research, brand research, giveaway audits, community audits, and controlled
+publishing.
+
+## Installation
+
+```bash
+claude plugin install hermes-tweet@flugins
+```
+
+After installing this Claude Code plugin, install the Hermes Agent plugin:
+
+```bash
+hermes plugins install Xquik-dev/hermes-tweet --enable
+```
+
+Hermes prompts for `XQUIK_API_KEY` during interactive install. For
+non-interactive installs, set the key in the Hermes runtime environment or
+`~/.hermes/.env` before calling `tweet_read`.
+
+## Usage
+
+Mention Hermes Tweet, X/Twitter research, Xquik workflows, social listening,
+launch monitoring, support triage, creator research, brand research, giveaway
+audits, community audits, or controlled publishing. Claude Code will load the
+skill guidance and keep X/Twitter operations on the Hermes Tweet route.
+
+## Safety
+
+- Use `tweet_explore` before any endpoint call.
+- Use `tweet_read` for read-only X/Twitter endpoints.
+- Use `tweet_action` only after explicit approval.
+- Keep `HERMES_TWEET_ENABLE_ACTIONS=false` unless actions are required.
+- Never paste credentials or secrets into chat.
+
+Repository: <https://github.com/Xquik-dev/hermes-tweet>

--- a/docs/plugin-catalog/hermes-tweet-plugin.md
+++ b/docs/plugin-catalog/hermes-tweet-plugin.md
@@ -42,9 +42,9 @@ skill guidance and keep X/Twitter operations on the Hermes Tweet route.
 
 ## Safety
 
-- Use `tweet_explore` before any endpoint call.
-- Use `tweet_read` for read-only X/Twitter endpoints.
-- Use `tweet_action` only after explicit approval.
+- Begin with `tweet_explore` before any endpoint call.
+- Fetch data through `tweet_read` for read-only X/Twitter endpoints.
+- Invoke `tweet_action` only after explicit approval.
 - Keep `HERMES_TWEET_ENABLE_ACTIONS=false` unless actions are required.
 - Never paste credentials or secrets into chat.
 

--- a/docs/plugin-catalog/index.md
+++ b/docs/plugin-catalog/index.md
@@ -7,6 +7,7 @@ This catalog provides detailed documentation for all available plugins in the Fl
 - [Docs Plugin](docs-plugin.md) - Generate and keep documentation in sync with your codebase
 - [Git Plugin](git-plugin.md) - Smart git workflow commands with intelligent conflict resolution
 - [Resolve CodeRabbit Plugin](resolve-coderabbit-plugin.md) - Walk through CodeRabbit inline PR comments, verify, fix, and batch-resolve
+- [Hermes Tweet Plugin](hermes-tweet-plugin.md) - Guide Hermes Agent X/Twitter workflows through Xquik
 
 ## Installation Reference
 

--- a/plugins/hermes-tweet/.claude-plugin/plugin.json
+++ b/plugins/hermes-tweet/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/Xquik-dev/hermes-tweet",
   "author": {
     "name": "Xquik",
-    "url": "https://github.com/Xquik-dev"
+    "email": "support@xquik.com"
   },
   "keywords": ["hermes-agent", "xquik", "twitter", "x", "social-media", "automation"]
 }

--- a/plugins/hermes-tweet/.claude-plugin/plugin.json
+++ b/plugins/hermes-tweet/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "hermes-tweet",
+  "version": "0.1.6",
+  "description": "Guide Hermes Agent X/Twitter workflows with Hermes Tweet, the native Xquik plugin for social listening, research, audits, and controlled publishing.",
+  "homepage": "https://github.com/Xquik-dev/hermes-tweet",
+  "author": {
+    "name": "Xquik",
+    "url": "https://github.com/Xquik-dev"
+  },
+  "keywords": ["hermes-agent", "xquik", "twitter", "x", "social-media", "automation"]
+}

--- a/plugins/hermes-tweet/skills/hermes-tweet/SKILL.md
+++ b/plugins/hermes-tweet/skills/hermes-tweet/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: hermes-tweet
+description: Use when a user wants to install or operate Hermes Tweet, the native Hermes Agent X/Twitter plugin for Xquik workflows.
+disable-model-invocation: false
+user-invocable: true
+allowed-tools: Read
+---
+
+# Hermes Tweet
+
+Use this skill when Claude Code users need Hermes Agent to search, inspect, or
+act on X/Twitter through Hermes Tweet.
+
+## Install
+
+Recommended Hermes install:
+
+```bash
+hermes plugins install Xquik-dev/hermes-tweet --enable
+```
+
+If Hermes discovers the plugin but leaves it disabled, run:
+
+```bash
+hermes plugins enable hermes-tweet
+```
+
+Hermes prompts for `XQUIK_API_KEY` during interactive install. In
+non-interactive installs, configure it in the Hermes runtime environment or in
+`~/.hermes/.env`. Do not ask the user to paste credentials or secrets into chat.
+
+## Workflow
+
+1. Use `tweet_explore` to discover the catalog route.
+2. Use `tweet_read` for read-only X/Twitter endpoints.
+3. Use `tweet_action` only after the user approves a write, private read,
+   monitor, webhook, extraction job, giveaway draw, or media operation.
+
+## Good Fits
+
+- Social listening
+- Launch monitoring
+- Support triage
+- Creator or brand research
+- Giveaway and community audits
+- Controlled publishing with explicit approval
+
+## Safety
+
+- Never request, reveal, or place credentials in tool arguments.
+- Never use account connection, re-authentication, API key, billing, credit
+  top-up, or support-ticket endpoints.
+- Do not guess endpoint paths. Use the catalog returned by `tweet_explore`.
+- Summarize any write or private action before calling `tweet_action`.

--- a/plugins/hermes-tweet/skills/hermes-tweet/SKILL.md
+++ b/plugins/hermes-tweet/skills/hermes-tweet/SKILL.md
@@ -31,9 +31,9 @@ non-interactive installs, configure it in the Hermes runtime environment or in
 
 ## Workflow
 
-1. Use `tweet_explore` to discover the catalog route.
-2. Use `tweet_read` for read-only X/Twitter endpoints.
-3. Use `tweet_action` only after the user approves a write, private read,
+1. First, discover the catalog route with `tweet_explore`.
+2. Then, call `tweet_read` for read-only X/Twitter endpoints.
+3. Finally, call `tweet_action` only after the user approves a write, private read,
    monitor, webhook, extraction job, giveaway draw, or media operation.
 
 ## Good Fits


### PR DESCRIPTION
Adds Hermes Tweet as a Flugins marketplace plugin with a source-native Claude plugin manifest, skill guidance, and catalog documentation. Hermes Tweet is the native Hermes Agent X/Twitter plugin for Xquik workflows, covering social listening, launch monitoring, support triage, creator research, brand research, giveaway audits, community audits, and controlled publishing.

Validation run:
- python3 -m json.tool .claude-plugin/marketplace.json
- python3 -m json.tool plugins/hermes-tweet/.claude-plugin/plugin.json
- claude plugin validate .
- claude plugin validate plugins/hermes-tweet
- git diff --check
- ASCII and secret scans for the new plugin payload and catalog entry
- Link checks for https://github.com/Xquik-dev/hermes-tweet and https://github.com/NousResearch/hermes-agent

Notes:
- The skill is read-only guidance and keeps writes/private operations behind explicit user approval.
- No credentials, private implementation details, or broken links are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hermes Tweet Plugin (v0.1.6) is now available, providing capabilities for exploring, reading, and performing actions on Twitter.

* **Documentation**
  * Added comprehensive plugin documentation including installation instructions, API key configuration guidance, and safety guidelines for Twitter interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->